### PR TITLE
Handle cases when impact and access aren't in the cvedetails

### DIFF
--- a/vuln-report.py
+++ b/vuln-report.py
@@ -3,7 +3,7 @@
 # Simple vulnerability report script
 # Runs against all known vulnerabilities in the Mongo database
 # Output is in CSV format
-# v0.1
+# v0.2
 # Andrew Magnusson
 
 from pymongo import MongoClient
@@ -74,7 +74,13 @@ def main():
                 listOfHosts += host + "; "
 
     # assemble record into a line of CSV
+            
             if (cvedetails): # if it's not empty!
+                if "impact" not in cvedetails:
+                    cvedetails["impact"] = {"availability": None, "confidentiality": None, "integrity": None }
+                if "access" not in cvedetails:
+                    cvedetails["access"] = {"authentication": None, "complexity": None, "vector": None }
+                    
                 record = [ cve, cvedetails['summary'], cvedetails['cvss'],
                         cvedetails['impact']['confidentiality'], cvedetails['impact']['integrity'],
                         cvedetails['impact']['availability'], cvedetails['access']['vector'],


### PR DESCRIPTION
I had to add these lines to allow the script to complete without error.   I think this may be because there is a difference between the CVEs I have in the DB compared to the ones that were present on Andy's system at the time of the scan that generated the sample scan results xml.