### PR TITLE
Correct the retrieval of CVEs from GVM's XML

### DIFF
--- a/gvm-insert.py
+++ b/gvm-insert.py
@@ -70,9 +70,19 @@ def main():
             result['cvss'] = cvss
 
             # these fields might contain one or more comma-separated values.
-            result['cve'] = nvtblock.find("cve").text.split(", ")
+            # result['cve'] = nvtblock.find("cve").text.split(", ")
             result['bid'] = nvtblock.find("bid").text.split(", ")
             result['xref'] = nvtblock.find("xref").text.split(", ")
+            
+            # Retrieving CVEs from GVM output
+            result['cve'] = []
+            try:
+                refs = nvtblock.find("refs").findall("ref")
+                for ref in refs:
+                    if ref.get('type') == "cve":
+                        result['cve'].append(ref.get('id'))
+            except:
+                pass
 
             # the issue is we don't know quite what will be in here for
             # any given vulnerability. So we'll just put them all in the


### PR DESCRIPTION
Inside `<nvt>` block from XML report the CVEs are being reported this way:

```
					<refs>
						<ref type="cve" id="CVE-2020-8746"/>
						<ref type="cve" id="CVE-2020-8747"/>
						<ref type="cve" id="CVE-2020-8749"/>
						<ref type="cve" id="CVE-2020-8752"/>
						<ref type="cve" id="CVE-2020-8753"/>
						<ref type="cve" id="CVE-2020-8754"/>
						...
					</refs>
```